### PR TITLE
feat(release): dual-publish @develit-io/general-codes to GH Packages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -21,6 +22,7 @@ jobs:
       - name: Configure npm authentication
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
 
       - name: Install NPM dependencies
         run: bun install
@@ -30,4 +32,10 @@ jobs:
 
       - name: Release General Codes
         run: npm publish --access public
+        working-directory: ./packages/general-codes
+
+      # Dual-publish na GH Packages — sjednocuje @develit-io scope pro konzumenty
+      # s bunfig scope → npm.pkg.github.com.
+      - name: Release General Codes to GitHub Packages
+        run: npm publish --registry https://npm.pkg.github.com
         working-directory: ./packages/general-codes

--- a/packages/general-codes/package.json
+++ b/packages/general-codes/package.json
@@ -4,6 +4,10 @@
   "description": "General Codes",
   "author": "Develit.io",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/develit-io/general-codes.git"
+  },
   "type": "module",
   "scripts": {
     "build": "unbuild",


### PR DESCRIPTION
## Co
Release workflow nově publishuje `@develit-io/general-codes` i na GH Packages (npm.pkg.github.com) vedle public npm: `packages: write`, GITHUB_TOKEN auth řádek (jen authToken, žádný scope mapping), dual-publish step + `repository` field v package.json (link balík↔repo).

## Proč
Sjednocení `@develit-io` scope na jednu registry — konzumenti s bunfig scope → GH Packages dostávají na npm-only balíky 404 (GH 302-mangle) → lockfile band-aidy. Párový PR: develit-io/develit-sdk#329. Kontext: Agent OS wiki `develit-sdk-private-distribution.md` § Trvalý fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)